### PR TITLE
hima: Rename Broadcom HCD file

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -85,7 +85,7 @@ vendor/lib/soundfx/libqcvirt.so
 vendor/lib/soundfx/libswdap.so
 
 # Bluetooth
-etc/firmware/BCM4356A2_001.003.015.0064.0175.hcd
+etc/firmware/BCM4356A2_001.003.015.0064.0175.hcd:etc/firmware/BCM4354A2_001.003.015.0064.0175.hcd
 
 # Camera
 bin/mm-qcamera-daemon


### PR DESCRIPTION
* Chip identifies as BCM4354, not BCM4356

Change-Id: Ia9373d114ae77c9127d6d375b2e8909ce8dcdf1d